### PR TITLE
Fix type of member tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ pub mod iter;
 mod list;
 mod reports;
 pub mod types;
-mod landing_pages;
 
 pub use crate::api::MailchimpApi;
 pub use crate::api_root::ApiRoot;
@@ -37,4 +36,3 @@ pub use crate::conversations::Conversations;
 pub use crate::internal::error_type::MailchimpErrorType;
 pub use crate::list::{ListFilter, Lists};
 pub use crate::reports::Reports;
-pub use crate::landing_pages::LandingPages;

--- a/src/types/list_members.rs
+++ b/src/types/list_members.rs
@@ -72,6 +72,16 @@ impl Default for ListMarketingPermision {
 }
 
 ///
+/// Returns up to 50 tags applied to this member. To retrieve all tags see `get_tags`.
+///
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(default)]
+pub struct MemberTag {
+    id: u64,
+    name: String,
+}
+
+///
 /// Open and click rates for this subscriber.
 ///
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -204,7 +214,7 @@ pub struct ListMember {
     pub tags_count: u64,
     /// The tags applied to this member.
     #[serde(default)]
-    pub tags: Vec<String>,
+    pub tags: Vec<MemberTag>,
     /// IP address the subscriber signed up from.
     #[serde(default)]
     pub ip_signup: String,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -41,7 +41,6 @@ mod list_webhooks;
 mod ping;
 mod report;
 mod workflow_email;
-mod landing_pages;
 
 pub use self::api_root::*;
 pub use self::authorized_apps::{AuthorizedAppType, AuthorizedAppsType, CreatedAuthorizedAppType};
@@ -82,4 +81,3 @@ pub use self::list_webhooks::*;
 pub use self::ping::*;
 pub use self::report::*;
 pub use self::workflow_email::*;
-pub use self::landing_pages::*;


### PR DESCRIPTION
It is sadly undocumented, but when Mailchimp returns a member, the `tags` are an array of objects containing an `id` and a `name` instead of an array of name strings.